### PR TITLE
feat: Add Docker support for easy installation and usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM golang:alpine AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum (if it exists)
+COPY go.mod go.sum* ./
+# Download dependencies
+RUN go mod download
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux go build -o secret-detector cmd/secret-detector/main.go
+
+# Final stage
+FROM alpine:latest
+
+# Install ca-certificates in case the tool needs to make HTTPS requests
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# Copy the binary from the build stage
+COPY --from=builder /app/secret-detector .
+
+# Default command
+ENTRYPOINT ["./secret-detector"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ cd cicd-secret-detector
 go build -o secret-detector cmd/secret-detector/main.go
 ```
 
+### Docker installation (recommended)
+If you don't have Go installed, you can use Docker and Docker Compose to run the tool.
+
+#### Build the image:
+```bash
+docker compose build
+```
+
+#### Run a scan:
+```bash
+docker compose run secret-detector
+```
+
+You can also pass additional arguments like `-format json`:
+```bash
+docker compose run secret-detector -dir /src -format json
+```
+
 ## Usage
 
 ### Basic Scan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  secret-detector:
+    build: .
+    volumes:
+      - .:/src
+    command: -dir /src


### PR DESCRIPTION
## Summary
Introduced Docker support to provide a simple, environment-independent way to run the `cicd-secret-detector`. This allows users to scan their codebases without requiring a local Go installation.

## Changes
* `Dockerfile`: Added a multi-stage Dockerfile to ensure a small final image size (~20MB).
  * Stage 1 (Build): Uses `golang:alpine` to compile the binary.
  * Stage 2 (Run): Uses `alpine:latest` for a minimal runtime environment.
* `docker-compose.yml`: Added a configuration file to simplify running the tool. It automatically mounts the current directory into the container, making it easy to scan local files with a single command.
* `README.md`: Updated the documentation to include Docker installation as a recommended method and provided clear instructions on how to build and run the container.

## How to Test
1. Make sure Docker is running on your system.

2. Build the image:
```bash
docker compose build
```

3. Run a scan on the current directory:
```bash
docker compose run secret-detector
```

4. Verify you can pass additional flags:
```bash
docker compose run secret-detector -dir /src -format json
```

## Why this is useful
Dockerizing the tool improves its portability and makes it much easier to integrate into CI/CD pipelines (like GitHub Actions, GitLab CI, or Jenkins) where installing Go manually might be less efficient than using a pre-built container.